### PR TITLE
bugfix: counter LSB used twice

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -126,4 +126,20 @@ describe('xid', () => {
     const obj2 = decode(data)
     assert.isTrue(xid.equals(Xid.fromValue(obj2.id)))
   })
+
+  it('generates unique ids', () => {
+    const ids = new Array(10000)
+      .fill(0)
+      .map(() => new Xid().toString())
+      .sort()
+
+    let lastId = ''
+    const duplicateFound = ids.some((id) => {
+      if (lastId === id) return true
+      lastId = id
+      return false
+    })
+
+    assert.isFalse(duplicateFound, 'duplicate ids found in 10k ids generated')
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export class Xid extends Uint8Array {
       }
 
       this[9] = state.counter >> 16
-      this[10] = state.counter & (0x00ffff >> 8)
+      this[10] = (state.counter >> 8) & 0xff
       this[11] = state.counter & 0x0000ff
     } else if (!(id instanceof Uint8Array) || id.length !== rawLen) {
       throw new Error(errInvalidID)


### PR DESCRIPTION
This PR fixes wrong bit shift causing last byte of the counter to be used twice resulting in only 254 unique ids when quickly generating ids.